### PR TITLE
Fix time-travel timestamp and update strata-core dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libloading"
@@ -814,7 +814,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "strata-concurrency"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "chrono",
  "dashmap",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "strata-core"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "bincode",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "strata-durability"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "crc32fast",
  "parking_lot",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "strata-engine"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "strata-executor"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "strata-intelligence"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "strata-security"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "serde",
 ]
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "strata-storage"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "stratadb"
 version = "0.5.1"
-source = "git+https://github.com/stratadb-labs/strata-core?branch=main#1bfbc7a9ac79dbfb0e125e5435ec51ab65c2fdc2"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#fae049e7ac2afed829e99cfd25b5152b927a67f4"
 dependencies = [
  "serde_json",
  "strata-executor",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "stratadb-node"
-version = "0.12.0"
+version = "0.12.5"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.12.5"
 edition = "2021"
 description = "Node.js bindings for StrataDB"
 license = "MIT"
-repository = "https://github.com/stratadb-labs/strata-node"
+repository = "https://github.com/strata-ai-labs/strata-node"
 
 [lib]
 crate-type = ["cdylib"]
@@ -21,10 +21,10 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["rt"] }
 
 # Use git dependency during development
-stratadb = { git = "https://github.com/stratadb-labs/strata-core", branch = "main" }
+stratadb = { git = "https://github.com/strata-ai-labs/strata-core", branch = "main" }
 
 # Intelligence crate for model download (embed feature only)
-strata-intelligence = { git = "https://github.com/stratadb-labs/strata-core", branch = "main", features = ["embed"], optional = true }
+strata-intelligence = { git = "https://github.com/strata-ai-labs/strata-core", branch = "main", features = ["embed"], optional = true }
 
 [build-dependencies]
 napi-build = "2"

--- a/__tests__/strata.test.js
+++ b/__tests__/strata.test.js
@@ -113,6 +113,15 @@ describe('Strata', () => {
       expect(await db.kv.get('tt')).toBe('v2');
       expect(await db.kv.get('tt', { asOf: ts })).toBe('v1');
     });
+
+    test('getVersioned timestamp roundtrip with asOf', async () => {
+      await db.kv.set('kv_rt', 'v1');
+      const vv = await db.kv.getVersioned('kv_rt');
+      await db.kv.set('kv_rt', 'v2');
+
+      expect(await db.kv.get('kv_rt')).toBe('v2');
+      expect(await db.kv.get('kv_rt', { asOf: vv.timestamp })).toBe('v1');
+    });
   });
 
   // =========================================================================
@@ -168,6 +177,15 @@ describe('Strata', () => {
       expect(vv).not.toBeNull();
       expect(vv.value).toBe(42);
       expect(typeof vv.version).toBe('number');
+    });
+
+    test('getVersioned timestamp roundtrip with asOf', async () => {
+      await db.state.set('sv_rt', 'v1');
+      const vv = await db.state.getVersioned('sv_rt');
+      await db.state.set('sv_rt', 'v2');
+
+      expect(await db.state.get('sv_rt')).toBe('v2');
+      expect(await db.state.get('sv_rt', { asOf: vv.timestamp })).toBe('v1');
     });
   });
 
@@ -262,6 +280,17 @@ describe('Strata', () => {
       const vv = await db.json.getVersioned('jv');
       expect(vv).not.toBeNull();
       expect(typeof vv.version).toBe('number');
+    });
+
+    test('getVersioned timestamp roundtrip with asOf', async () => {
+      await db.json.set('jv_rt', '$', { v: 1 });
+      const vv = await db.json.getVersioned('jv_rt');
+      await db.json.set('jv_rt', '$', { v: 2 });
+
+      const current = await db.json.get('jv_rt', '$');
+      expect(current.v).toBe(2);
+      const past = await db.json.get('jv_rt', '$', { asOf: vv.timestamp });
+      expect(past.v).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Update git dependency URL from `stratadb-labs` to `strata-ai-labs`
- Pull latest `strata-core` with timestamp mismatch fix (`fae049e7`)
- Add `getVersioned` timestamp roundtrip tests for KV, State, and JSON

The upstream fix (strata-ai-labs/strata-core#1123) resolved a bug where `getVersioned()` returned the application-layer timestamp instead of the storage-layer timestamp, causing `asOf` reads with that timestamp to return `null`.

## Test plan
- [x] 3 new roundtrip tests pass (`getVersioned timestamp roundtrip with asOf`)
- [x] Full test suite passes (96/96)

🤖 Generated with [Claude Code](https://claude.com/claude-code)